### PR TITLE
Calculate and display volunteer totals

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -29,16 +29,18 @@ const HeroSection = () => {
   const secondaryButton = heroContent.secondaryButton || "Learn More";
   
   // Simple stats using the existing content system
+  // Display-only offsets requested via Slack: add 602 volunteers and 1,204 hours.
+  // This does not alter underlying calculations; it only adjusts what's rendered.
   const statsData = [
     { 
       icon: Users, 
       label: impactContent.volunteers_label || "Active Volunteers", 
-      value: (adminStats.activeVolunteers || siteStatistics?.active_volunteers?.display_value || parseInt(impactContent.active_volunteers)) || 0
+      value: ((adminStats.activeVolunteers || siteStatistics?.active_volunteers?.display_value || parseInt(impactContent.active_volunteers)) || 0) + 602
     },
     { 
       icon: Clock, 
       label: impactContent.hours_label || "Hours Contributed", 
-      value: impactContent.hours_contributed || "0"
+      value: ((typeof impactContent.hours_contributed === 'number' ? impactContent.hours_contributed : parseInt(impactContent.hours_contributed)) || 0) + 1204
     },
     { 
       icon: Building, 

--- a/src/components/sections/ImpactSection.tsx
+++ b/src/components/sections/ImpactSection.tsx
@@ -19,13 +19,13 @@ const ImpactSection = () => {
     { 
       icon: Users, 
       label: impactContent.volunteers_label || <DynamicText page="homepage" section="impact" contentKey="volunteers_label" fallback=<DynamicText page="impact" section="main" contentKey="volunteers_label" fallback="Active Volunteers" /> />, 
-      value: (adminStats.activeVolunteers || siteStatistics?.active_volunteers?.display_value || parseInt(impactContent.active_volunteers)) || 0,
+      value: ((adminStats.activeVolunteers || siteStatistics?.active_volunteers?.display_value || parseInt(impactContent.active_volunteers)) || 0) + 602,
       description: aboutImpactContent.volunteers_description || <DynamicText page="impact" section="main" contentKey="volunteers_description" fallback="Passionate individuals serving Upland" />
     },
     { 
       icon: Clock, 
       label: impactContent.hours_label || <DynamicText page="homepage" section="impact" contentKey="hours_label" fallback=<DynamicText page="impact" section="main" contentKey="hours_label" fallback="Hours Contributed" /> />, 
-      value: impactContent.hours_contributed || "0",
+      value: (((typeof impactContent.hours_contributed === 'number' ? impactContent.hours_contributed : parseInt(impactContent.hours_contributed)) || 0) + 1204),
       description: aboutImpactContent.hours_description || <DynamicText page="impact" section="main" contentKey="hours_description" fallback="Collective time dedicated to service" />
     },
     { 


### PR DESCRIPTION
Add display-only offsets for total volunteers (+602) and hours (+1,204) to homepage metrics.

---
[Slack Thread](https://aidev-gz64679.slack.com/archives/C093Y7BMAUS/p1757777063767189?thread_ts=1757777063.767189&cid=C093Y7BMAUS)

<a href="https://cursor.com/background-agent?bcId=bc-4a68aa68-020e-41f3-bbcc-f3dfbde9cdb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a68aa68-020e-41f3-bbcc-f3dfbde9cdb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

